### PR TITLE
Set up reactdown/runtime for easy vendoring

### DIFF
--- a/runtime.js
+++ b/runtime.js
@@ -1,0 +1,10 @@
+/**
+ * @copyright 2016-present, Reactdown team
+ */
+
+// All modules used by compiled markdown files.
+//
+// When using webpack, you will probably want to import 'reactdown/runtime' in a
+// vendor bundle to cut down on per-file weight.
+module.exports.components = require('./components');
+module.exports.DocumentContext = require('./DocumentContext').default;


### PR DESCRIPTION
Allows for including shared reactdown runtime code in a common bundle, to avoid including it in each chunk when building markdown files into multiple chunks.

I also snuck in exports; though I don't have an immediate use for them