### PR TITLE
Resolve images via webpack

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,6 @@ import {
   toParseConfig
 } from './Config';
 
-
 export function renderToString(value: string, config: Config = {}): {code: string} {
   config = mergeConfig(defaultConfig, config);
   let renderConfig = toRenderConfig(config);

--- a/src/webpack.js
+++ b/src/webpack.js
@@ -3,11 +3,17 @@
  * @flow
  */
 
-import {renderToString} from './index';
+import generate from 'babel-generator';
+import loaderUtils from 'loader-utils';
+import parse from './parse';
+import visit from 'unist-util-visit';
+import {renderToProgram} from './render';
 import {
   findConfig,
   mergeConfig,
-  parseConfigFromQuery
+  parseConfigFromQuery,
+  toParseConfig,
+  toRenderConfig
 } from './Config';
 
 /**
@@ -16,23 +22,77 @@ import {
 function reactdown(source: string): string {
   this.cacheable();
 
-  let compiler = this._compiler;
+  let config = completeConfig(this._compiler, this.query);
 
+  let mdast = toMDAST(config, source);
+  resolveImages(config, this, mdast); // Mutates mdast.
+
+  let jsast = toJSAST(config, mdast);
+  let compiledSource = toSource(jsast);
+  return unwrapUrls(compiledSource);
+}
+
+function completeConfig(compiler, query) {
   // We read the config once. That means on changes to config one must restart
   // the compiler.
   //
   // TODO: Improve on that, so changes to configration do not require restarting
   // Webpack compiler.
   if (compiler.__reactdownConfig === undefined) {
+    // TODO: Error handling
+    // https://github.com/andreypopp/reactdown/pull/16/files#diff-821a16d38cf4ff69edc6b5b48313aa0bR67
     compiler.__reactdownConfig = findConfig(compiler.context).config;
   }
 
-  let config = mergeConfig(
+  return mergeConfig(
     compiler.__reactdownConfig,
-    parseConfigFromQuery(this.query)
+    parseConfigFromQuery(query)
   );
+}
 
-  return renderToString(source, config).code;
+function toMDAST(config, source) {
+  let parseConfig = toParseConfig(config);
+  // TODO: Error handling
+  // https://github.com/andreypopp/reactdown/pull/16/files#diff-821a16d38cf4ff69edc6b5b48313aa0bR49
+  return parse(source, parseConfig);
+}
+
+// Please note: This mutates the URL of any images in the MDAST!
+function resolveImages(config, loader, mdast) {
+  visit(mdast, 'image', (image) => {
+    // Ignore remote URLs, either `scheme://` or `//`
+    if (/^[^\/]+\/\//.test(image.url)) return;
+    image.url = wrapUrl(loaderUtils.urlToRequest(image.url));
+  });
+}
+
+function toJSAST(config, mdast) {
+  let renderConfig = toRenderConfig(config);
+  // TODO: Error handling
+  // ???
+  return renderToProgram(mdast, renderConfig);
+}
+
+function toSource(jsast) {
+  return generate(jsast, {
+    compact: false,
+    concise: false
+  }).code;
+}
+
+// Webpack loaders can't resolve downstream loaders inline.  Instead, they're
+// expected to emit calls to `require()`.  In order to avoid jumping through
+// JSAST hoops, we transform URLs in the MDAST, and then find/replace them with
+// require statements in the generated source.  This is the same strategy
+// employed by Webpack's css-loader.
+function wrapUrl(url) {
+  return `___RD_URL___${url}___END_RD_URL___`;
+}
+
+function unwrapUrls(source) {
+  return source.replace(new RegExp('"___RD_URL___([^"]+)___END_RD_URL___"', 'g'), (_match, resolvedPath) => {
+    return `require("${resolvedPath}")`;
+  });
 }
 
 module.exports = reactdown;


### PR DESCRIPTION
This patch sets up the webpack loader to convert image URLs into `require()` calls so that webpack can manage images referenced by markdown files.

There was a fair bit of refactoring as part of this, which might help your schema branch.  In particular, now that the loader needs to play with intermediate representations, I think you get to avoid the error disambiguation at https://github.com/andreypopp/reactdown/pull/16/files#diff-821a16d38cf4ff69edc6b5b48313aa0bR49